### PR TITLE
Add missing JAXB dependency for Java 9+ for embedded Tomcat setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,14 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.4.0-b180830.0359</version>
+        </dependency>
+
+
 
 
 


### PR DESCRIPTION
This dependency is being added to the POM file to fix the deploy for Java 9+ .Please refer to the ticket for details.

https://mitlibraries.atlassian.net/browse/DOS-157