### PR TITLE
Add JWT support for endpoints.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,35 @@
             <version>1.11.705</version>
         </dependency>
 
+        <dependency>
+            <!-- JSON Web Token Support -->
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+
+        <dependency>
+            <!-- Model Mapper -->
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper</artifactId>
+            <version>2.3.5</version>
+        </dependency>
+
+        <dependency>
+            <!-- Automated JSON API documentation for API's built with Spring -->
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>2.9.2</version>
+        </dependency>
+
+
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.0</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/dto/UserDataDTO.java
+++ b/src/main/java/dto/UserDataDTO.java
@@ -1,0 +1,49 @@
+package dto;
+
+import edu.mit.dos.model.Role;
+
+import java.util.List;
+
+public class UserDataDTO {
+
+    private String username;
+
+    private String email;
+
+    private String password;
+
+    List<Role> roles;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<Role> roles) {
+        this.roles = roles;
+    }
+
+}

--- a/src/main/java/dto/UserResponseDTO.java
+++ b/src/main/java/dto/UserResponseDTO.java
@@ -1,0 +1,50 @@
+package dto;
+
+import edu.mit.dos.model.Role;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+public class UserResponseDTO {
+
+    private Integer id;
+
+    private String username;
+
+    private String email;
+
+    List<Role> roles;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<Role> roles) {
+        this.roles = roles;
+    }
+
+}

--- a/src/main/java/edu/mit/dos/DataLoader.java
+++ b/src/main/java/edu/mit/dos/DataLoader.java
@@ -1,0 +1,30 @@
+package edu.mit.dos;
+
+import edu.mit.dos.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataLoader implements ApplicationRunner {
+
+    private UserService userRepository;
+
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationRunner.class);
+
+
+    @Autowired
+    public DataLoader(UserService userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void run(ApplicationArguments applicationArguments) throws Exception {
+        logger.debug("Okay here");
+
+    }
+}

--- a/src/main/java/edu/mit/dos/ServiceConfig.java
+++ b/src/main/java/edu/mit/dos/ServiceConfig.java
@@ -32,6 +32,9 @@ public class ServiceConfig {
     @NotNull
     private String baseurl;
 
+    @NotNull
+    private String mode;
+
     public String getAccessKey() {
         return accessKey;
     }
@@ -78,5 +81,13 @@ public class ServiceConfig {
 
     public void setBaseurl(String baseurl) {
         this.baseurl = baseurl;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
     }
 }

--- a/src/main/java/edu/mit/dos/SpringMain.java
+++ b/src/main/java/edu/mit/dos/SpringMain.java
@@ -1,9 +1,19 @@
 package edu.mit.dos;
 
+import edu.mit.dos.model.Role;
+import edu.mit.dos.model.User;
+import edu.mit.dos.service.UserService;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.context.annotation.Bean;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 
 /**
@@ -11,6 +21,13 @@ import org.springframework.boot.web.support.SpringBootServletInitializer;
  */
 @SpringBootApplication
 public class SpringMain extends SpringBootServletInitializer {
+
+    @Autowired (required = false)
+    UserService userService;
+
+    @Autowired(required = false)
+    ServiceConfig serviceConfig;
+
 
     public static void main(String[] args) {
         SpringApplication.run(SpringMain.class, args);
@@ -20,4 +37,55 @@ public class SpringMain extends SpringBootServletInitializer {
     protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
         return builder.sources(SpringMain.class);
     }
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+
+    // TODO Temporary. Remove when the database is set up with users
+    @PostConstruct
+    public void init() {
+        System.out.println("Spring Boot Application Initializing . . .");
+
+        if (userService == null) {
+            System.err.println("Warning: UserService not injected");
+            return;
+        }
+
+        if (serviceConfig == null) {
+            return;
+        }
+
+        if (serviceConfig.getMode().equals("testing") == false) {
+            return;
+        }
+
+        // TODO Temporary. Remove when the database is set up with users
+
+        // Add test users (admin and client) if in the test mode
+
+        System.out.println("Warning: Spring test mode. Adding users.");
+
+        final User admin = new User();
+        admin.setUsername("admin");
+        admin.setPassword("admin");
+        admin.setEmail("admin@email.com");
+        admin.setRoles(new ArrayList<>(Arrays.asList(Role.ROLE_ADMIN)));
+
+        userService.signup(admin);
+
+        final User client = new User();
+        client.setUsername("client");
+        client.setPassword("client");
+        client.setEmail("client@email.com");
+        client.setRoles(new ArrayList<>(Arrays.asList(Role.ROLE_CLIENT)));
+
+        userService.signup(client);
+
+        System.out.println("Warning: Spring test mode. Users added.");
+
+
+    }
+
 }

--- a/src/main/java/edu/mit/dos/application/CustomException.java
+++ b/src/main/java/edu/mit/dos/application/CustomException.java
@@ -1,0 +1,26 @@
+package edu.mit.dos.application;
+
+import org.springframework.http.HttpStatus;
+
+public class CustomException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String message;
+  private final HttpStatus httpStatus;
+
+  public CustomException(String message, HttpStatus httpStatus) {
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+}

--- a/src/main/java/edu/mit/dos/controller/UserController.java
+++ b/src/main/java/edu/mit/dos/controller/UserController.java
@@ -1,0 +1,91 @@
+package edu.mit.dos.controller;
+
+
+import dto.UserDataDTO;
+import dto.UserResponseDTO;
+import edu.mit.dos.model.User;
+import edu.mit.dos.service.UserService;
+import io.swagger.annotations.*;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/users")
+@Api(tags = "users")
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @PostMapping("/signin")
+    @ApiOperation(value = "${UserController.signin}")
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = "Something went wrong"), //
+            @ApiResponse(code = 422, message = "Invalid username/password supplied")})
+    public String login(//
+                        @ApiParam("Username") @RequestParam String username, //
+                        @ApiParam("Password") @RequestParam String password) {
+        return userService.signin(username, password);
+    }
+
+    @PostMapping("/signup")
+    @ApiOperation(value = "${UserController.signup}")
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = "Something went wrong"), //
+            @ApiResponse(code = 403, message = "Access denied"), //
+            @ApiResponse(code = 422, message = "Username is already in use"), //
+            @ApiResponse(code = 500, message = "Expired or invalid JWT token")})
+    public String signup(@ApiParam("Signup User") @RequestBody UserDataDTO user) {
+        return userService.signup(modelMapper.map(user, User.class));
+    }
+
+    @DeleteMapping(value = "/{username}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "${UserController.delete}")
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = "Something went wrong"), //
+            @ApiResponse(code = 403, message = "Access denied"), //
+            @ApiResponse(code = 404, message = "The user doesn't exist"), //
+            @ApiResponse(code = 500, message = "Expired or invalid JWT token")})
+    public String delete(@ApiParam("Username") @PathVariable String username) {
+        userService.delete(username);
+        return username;
+    }
+
+    @GetMapping(value = "/{username}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiOperation(value = "${UserController.search}", response = UserResponseDTO.class)
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = "Something went wrong"), //
+            @ApiResponse(code = 403, message = "Access denied"), //
+            @ApiResponse(code = 404, message = "The user doesn't exist"), //
+            @ApiResponse(code = 500, message = "Expired or invalid JWT token")})
+    public UserResponseDTO search(@ApiParam("Username") @PathVariable String username) {
+        return modelMapper.map(userService.search(username), UserResponseDTO.class);
+    }
+
+    @GetMapping(value = "/me")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_CLIENT')")
+    @ApiOperation(value = "${UserController.me}", response = UserResponseDTO.class)
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = "Something went wrong"), //
+            @ApiResponse(code = 403, message = "Access denied"), //
+            @ApiResponse(code = 500, message = "Expired or invalid JWT token")})
+    public UserResponseDTO whoami(HttpServletRequest req) {
+        return modelMapper.map(userService.whoami(req), UserResponseDTO.class);
+    }
+
+    @GetMapping("/refresh")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_CLIENT')")
+    public String refresh(HttpServletRequest req) {
+        return userService.refresh(req.getRemoteUser());
+    }
+
+}

--- a/src/main/java/edu/mit/dos/model/Role.java
+++ b/src/main/java/edu/mit/dos/model/Role.java
@@ -1,0 +1,12 @@
+package edu.mit.dos.model;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum Role implements GrantedAuthority {
+  ROLE_ADMIN, ROLE_CLIENT;
+
+  public String getAuthority() {
+    return name();
+  }
+
+}

--- a/src/main/java/edu/mit/dos/model/User.java
+++ b/src/main/java/edu/mit/dos/model/User.java
@@ -1,0 +1,83 @@
+package edu.mit.dos.model;
+
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.Size;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Size(min = 4, max = 255, message = "Minimum username length: 4 characters")
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Size(min = 8, message = "Minimum password length: 8 characters")
+    private String password;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    List<Role> roles;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<Role> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "username='" + username + '\'' +
+                ", email='" + email + '\'' +
+                ", password='" + password + '\'' +
+                ", roles=" + roles +
+                '}';
+    }
+}

--- a/src/main/java/edu/mit/dos/object/ObjectService.java
+++ b/src/main/java/edu/mit/dos/object/ObjectService.java
@@ -5,6 +5,7 @@ import edu.mit.dos.model.DigitalObject;
 import edu.mit.dos.persistence.DigitalObjectJpaRepository;
 import edu.mit.dos.persistence.FileJpaRepository;
 import edu.mit.dos.persistence.ObjectFilePersistence;
+import edu.mit.dos.repository.UserRepository;
 import edu.mit.dos.storage.StorageInterfaceFactory;
 import edu.mit.dos.util.FileConverter;
 import org.slf4j.Logger;

--- a/src/main/java/edu/mit/dos/repository/UserRepository.java
+++ b/src/main/java/edu/mit/dos/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package edu.mit.dos.repository;
+
+import edu.mit.dos.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.transaction.Transactional;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+
+  boolean existsByUsername(String username);
+
+  User findByUsername(String username);
+
+  @Transactional
+  void deleteByUsername(String username);
+
+}

--- a/src/main/java/edu/mit/dos/security/JwtTokenFilter.java
+++ b/src/main/java/edu/mit/dos/security/JwtTokenFilter.java
@@ -1,0 +1,46 @@
+package edu.mit.dos.security;
+
+import edu.mit.dos.application.CustomException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtTokenFilter.class);
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest,
+                                    HttpServletResponse httpServletResponse, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = jwtTokenProvider.resolveToken(httpServletRequest);
+        try {
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                Authentication auth = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        } catch (CustomException ex) {
+            logger.error("Error:{}", ex);
+            SecurityContextHolder.clearContext(); // important
+            httpServletResponse.sendError(ex.getHttpStatus().value(), ex.getMessage());
+            return;
+        }
+
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+
+    public JwtTokenFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+}

--- a/src/main/java/edu/mit/dos/security/JwtTokenFilterConfigurer.java
+++ b/src/main/java/edu/mit/dos/security/JwtTokenFilterConfigurer.java
@@ -1,0 +1,22 @@
+package edu.mit.dos.security;
+
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class JwtTokenFilterConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    public JwtTokenFilterConfigurer(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        JwtTokenFilter customFilter = new JwtTokenFilter(jwtTokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+}

--- a/src/main/java/edu/mit/dos/security/JwtTokenProvider.java
+++ b/src/main/java/edu/mit/dos/security/JwtTokenProvider.java
@@ -1,0 +1,107 @@
+package edu.mit.dos.security;
+
+import edu.mit.dos.application.CustomException;
+import edu.mit.dos.model.Role;
+import edu.mit.dos.persistence.ObjectFilePersistenceImpl;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
+
+    // Temporary. Storing the static key here temporarily. To be moved to applications secrets server.
+    @Value("${security.jwt.token.secret-key:secret-key}") // security.jwt.token.secret-key
+    private String secretKey;
+
+    @Value("${security.jwt.token.expire-length:3600000}")
+    private long validityInMilliseconds = 3600000; // 1h
+
+    @Autowired
+    private MyUserDetails myUserDetails;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String createToken(String username, List<Role> roles) {
+
+        final Claims claims = Jwts.claims().setSubject(username);
+        claims.put("auth", roles.stream().map(s -> new SimpleGrantedAuthority(s.getAuthority())).filter(Objects::nonNull).collect(Collectors.toList()));
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()//
+                .setClaims(claims)//
+                .setIssuedAt(now)//
+                .setExpiration(validity)//
+                .signWith(SignatureAlgorithm.HS256, secretKey)//
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        // logger.debug("Getting details for token=" + token);
+
+        final UserDetails userDetails = myUserDetails.loadUserByUsername(getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getUsername(String token) {
+        // logger.debug("Getting username for token=" + token);
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest req) {
+        String bearerToken = req.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            String s = bearerToken.substring(7); //FIXME buggy for tests?
+            s = s.trim();
+            s = s.replace(": ", "");
+            System.out.println("Resolved token=" + s);
+            return s;
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+
+        try {
+            // System.out.println("Secret key:" + secretKey);
+            token = token.trim();
+            token = token.replace(": ", "");
+            // System.out.println("Token:" + token);
+
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            // logger.debug("Claim parsed for token:{}", token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            logger.error("Error validating token:", e);
+            throw new CustomException("Expired or invalid JWT token", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/edu/mit/dos/security/MyUserDetails.java
+++ b/src/main/java/edu/mit/dos/security/MyUserDetails.java
@@ -1,0 +1,41 @@
+package edu.mit.dos.security;
+
+
+import edu.mit.dos.model.User;
+import edu.mit.dos.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MyUserDetails implements UserDetailsService {
+
+    private static final Logger logger = LoggerFactory.getLogger(MyUserDetails.class);
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        final User user = userRepository.findByUsername(username);
+
+        if (user == null) {
+            throw new UsernameNotFoundException("User '" + username + "' not found");
+        }
+
+        return org.springframework.security.core.userdetails.User//
+                .withUsername(username)//
+                .password(user.getPassword())//
+                .authorities(user.getRoles())//
+                .accountExpired(false)//
+                .accountLocked(false)//
+                .credentialsExpired(false)//
+                .disabled(false)//
+                .build();
+    }
+
+}

--- a/src/main/java/edu/mit/dos/security/WebSecurityConfig.java
+++ b/src/main/java/edu/mit/dos/security/WebSecurityConfig.java
@@ -1,0 +1,83 @@
+package edu.mit.dos.security;
+
+import edu.mit.dos.persistence.ObjectFilePersistenceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSecurityConfig.class);
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        // Disable CSRF (cross site request forgery)
+        http.csrf().disable();
+
+        // No session will be created or used by spring security
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        // Entry points
+        http.authorizeRequests()//
+                .antMatchers("/users/signin").permitAll()//
+                .antMatchers("/users/signup").permitAll()//
+                .antMatchers("/h2-console/**/**").permitAll()
+                // Disallow everything else..
+                .anyRequest().authenticated();
+
+        // If a user try to access a resource without having enough permissions
+        http.exceptionHandling().accessDeniedPage("/login");
+
+        // Apply JWT
+        http.apply(new JwtTokenFilterConfigurer(jwtTokenProvider));
+
+        // Optional, if you want to test the API from a browser
+        // http.httpBasic();
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        // Allow swagger to be accessed without authentication
+        web.ignoring().antMatchers("/v2/api-docs")//
+                .antMatchers("/swagger-resources/**")//
+                .antMatchers("/swagger-ui.html")//
+                .antMatchers("/configuration/**")//
+                .antMatchers("/webjars/**")//
+                .antMatchers("/public")
+
+                // Un-secure H2 Database (for testing purposes, H2 console shouldn't be unprotected in production)
+                .and()
+                .ignoring()
+                .antMatchers("/h2-console/**/**");
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(12);
+    }
+
+    @Override
+    @Bean
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+}

--- a/src/main/java/edu/mit/dos/service/UserService.java
+++ b/src/main/java/edu/mit/dos/service/UserService.java
@@ -1,0 +1,20 @@
+package edu.mit.dos.service;
+
+import edu.mit.dos.model.User;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface UserService {
+
+    String signup(User user);
+
+    String signin(String username, String password);
+
+    void delete(String username);
+
+    User search(String username);
+
+    User whoami(HttpServletRequest req);
+
+    String refresh(String remoteUser);
+}

--- a/src/main/java/edu/mit/dos/service/UserServiceImpl.java
+++ b/src/main/java/edu/mit/dos/service/UserServiceImpl.java
@@ -1,0 +1,79 @@
+package edu.mit.dos.service;
+
+
+import edu.mit.dos.application.CustomException;
+import edu.mit.dos.model.User;
+import edu.mit.dos.repository.UserRepository;
+import edu.mit.dos.security.JwtTokenProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+@Qualifier
+public class UserServiceImpl implements UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    private static final Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
+
+
+    public String signin(String username, String password) {
+        try {
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+            return jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoles());
+        } catch (AuthenticationException e) {
+            throw new CustomException("Invalid username/password supplied", HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    public String signup(User user) {
+        if (!userRepository.existsByUsername(user.getUsername())) {
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
+            userRepository.save(user);
+            return jwtTokenProvider.createToken(user.getUsername(), user.getRoles());
+        } else {
+            throw new CustomException("Username is already in use", HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+    }
+
+    public void delete(String username) {
+        userRepository.deleteByUsername(username);
+    }
+
+    public User search(String username) {
+        User user = userRepository.findByUsername(username);
+        if (user == null) {
+            return null;
+        }
+        return user;
+    }
+
+    public User whoami(HttpServletRequest req) {
+        return userRepository.findByUsername(jwtTokenProvider.getUsername(jwtTokenProvider.resolveToken(req)));
+    }
+
+    public String refresh(String username) {
+        return jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoles());
+    }
+
+}

--- a/src/main/java/edu/mit/dos/util/FileConverter.java
+++ b/src/main/java/edu/mit/dos/util/FileConverter.java
@@ -1,13 +1,18 @@
 package edu.mit.dos.util;
 
+import edu.mit.dos.service.UserServiceImpl;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
 public class FileConverter {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
 
     private static String PREFIX = "temp";
 
@@ -19,7 +24,12 @@ public class FileConverter {
         }
 
         final URL uri = new URL(httpLink);
-        FileUtils.copyURLToFile(uri, f);
+        try {
+            FileUtils.copyURLToFile(uri, f);
+        } catch (IOException e) {
+            logger.error("Error copying file to url. {}", e);
+            throw e;
+        }
         return f;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,11 @@ serviceConfig.minter=pid
 # application-stage.properties. See README.md for what that file should like like.
 
 spring.profiles.active=dev
+
+# Note: temporary credentials for testing
+
+security.jwt.token.secret-key=secret-key
+security.jwt.token.expire-length=300000
+
+# Note: temporary testing mode for JWT testing
+serviceConfig.mode=testing

--- a/src/test/java/edu/mit/dos/auth/AuthServiceIT.java
+++ b/src/test/java/edu/mit/dos/auth/AuthServiceIT.java
@@ -1,0 +1,62 @@
+package edu.mit.dos.auth;
+
+import edu.mit.dos.model.DigitalObject;
+import edu.mit.dos.service.UserService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+
+/**
+ * Checks that object end points don't work without API auth
+ * Note: Test starts the server
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ComponentScan("edu.mit.dos.persistence, edu.mit.dos.service")
+public class AuthServiceIT {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Test
+    public void shouldFailEndPointsWithoutAuth() {
+        final MultiValueMap<String, String> map = getRequestMap();
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
+        final String postBody = this.restTemplate.postForObject("/object", request, String.class);
+        assertThat(postBody.contains("Required String parameter 'username' is not present"));
+
+        final DigitalObject getBody = this.restTemplate.getForObject("/object?oid=" + postBody, DigitalObject.class);
+        assertThat(getBody == null); // TODO update to exception
+
+        final MultiValueMap<String, String> updatedMap = new LinkedMultiValueMap<>();
+        final HttpEntity<MultiValueMap<String, String>> updateRequest = new HttpEntity<>(updatedMap, new HttpHeaders());
+        final String patchBody = this.restTemplate.patchForObject("/object", updateRequest, String.class);
+        assertThat(patchBody.contains("Expired or Invalid JWT Token"));
+    }
+
+    private MultiValueMap<String, String> getRequestMap() {
+        final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("handle", "hdl.net");
+        map.add("title", "Item Title");
+        map.add("metadata_system", "dome");
+        map.add("source_system", "archivesspace");
+        map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
+        return map;
+    }
+
+
+}

--- a/src/test/java/edu/mit/dos/object/HeaderRequestInterceptor.java
+++ b/src/test/java/edu/mit/dos/object/HeaderRequestInterceptor.java
@@ -1,0 +1,26 @@
+package edu.mit.dos.object;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+
+public class HeaderRequestInterceptor implements ClientHttpRequestInterceptor {
+
+    private final String headerName;
+
+    private final String headerValue;
+
+    public HeaderRequestInterceptor(String headerName, String headerValue) {
+        this.headerName = headerName;
+        this.headerValue = headerValue;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        request.getHeaders().set(headerName, headerValue);
+        return execution.execute(request, body);
+    }
+}

--- a/src/test/java/edu/mit/dos/object/ObjectServiceIT.java
+++ b/src/test/java/edu/mit/dos/object/ObjectServiceIT.java
@@ -1,18 +1,29 @@
 package edu.mit.dos.object;
 
 import edu.mit.dos.model.DigitalObject;
+import edu.mit.dos.model.Role;
+import edu.mit.dos.model.User;
+import edu.mit.dos.service.UserService;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.fail;
 
 
 /**
@@ -20,78 +31,111 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ComponentScan("edu.mit.dos.persistence, edu.mit.dos.service")
 public class ObjectServiceIT {
+
+    private static final String USER_ADMIN = "admin1";
+    private static final String USER_PASSWORD = "admin1";
+    private static final String USER_EMAIL = "admin1@email.com";
+    private static final String CLIENT_USERNAME = "client1";
+    private static final String PASSWORD = "client1";
+    private static final String CLIENT_EMAIL_COM = "client1@email.com";
+
+    @Autowired
+    UserService userService;
 
     @Autowired
     TestRestTemplate restTemplate;
 
+    /**
+     * Sets up authentication, tokens, etc.
+     */
+    @Before
+    public void setupAuth() {
+
+        if (userService == null) {
+            fail("Autowired user service null.");
+        }
+
+        if (userService.search(USER_ADMIN) != null) {
+            return; // user already exists; do not recreate the user
+        }
+
+        final User admin = new User();
+        admin.setUsername(USER_ADMIN);
+        admin.setPassword(USER_PASSWORD);
+        admin.setEmail(USER_EMAIL);
+        admin.setRoles(new ArrayList<>(Arrays.asList(Role.ROLE_ADMIN)));
+        userService.signup(admin);
+        final User client = new User();
+        client.setUsername(CLIENT_USERNAME);
+        client.setPassword(PASSWORD);
+        client.setEmail(CLIENT_EMAIL_COM);
+        client.setRoles(new ArrayList<>(Arrays.asList(Role.ROLE_CLIENT)));
+        userService.signup(client);
+
+        // Get the token:
+
+        // Pattern: curl -X POST 'http://localhost:8080/users/signin?username=admin&password=admin'
+
+        final MultiValueMap<String, String> map1 = new LinkedMultiValueMap<>();
+        map1.add("username", USER_ADMIN);
+        map1.add("password", USER_PASSWORD);
+        final HttpEntity<MultiValueMap<String, String>> request1 = new HttpEntity<>(map1, new HttpHeaders());
+        final String auth = this.restTemplate.postForObject("/users/signin", request1, String.class);
+        final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+        interceptors.add(new HeaderRequestInterceptor("Authorization: Bearer ", auth));
+        this.restTemplate.getRestTemplate().setInterceptors(interceptors);
+
+    }
+
     @Test
     public void testGet() {
-        MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
-        map.add("handle", "hdl.net");
-        map.add("title", "Item Title");
-        map.add("metadata_system", "dome");
-        map.add("source_system", "archivesspace");
-        map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
-        String body = this.restTemplate.postForObject("/object",  request,String.class);
+        final MultiValueMap<String, String> map = getRequestParameters();
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
+        final String body = this.restTemplate.postForObject("/object", request, String.class);
+        System.out.println("Results:" + body);
         assertThat(body).isNotNull();
-        DigitalObject body2 = this.restTemplate.getForObject("/object?oid="+body, DigitalObject.class);
+
+        final DigitalObject body2 = this.restTemplate.getForObject("/object?oid=" + body, DigitalObject.class);
         assertThat(body2.getHandle()).isEqualTo("hdl.net");
         assertThat(body2.getTitle()).isEqualTo("Item Title");
     }
 
     @Test
     public void testPost() {
-        MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
-        map.add("handle", "hdl.net");
-        map.add("title", "Item Title");
-        map.add("metadata_system", "dome");
-        map.add("source_system", "archivesspace");
-        map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
-        String body = this.restTemplate.postForObject("/object",  request,String.class);
+        final MultiValueMap<String, String> map = getRequestParameters();
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
+        String body = this.restTemplate.postForObject("/object", request, String.class);
         assertThat(body).isNotNull();
-        DigitalObject body2 = this.restTemplate.getForObject("/object?oid="+body, DigitalObject.class);
+        final DigitalObject body2 = this.restTemplate.getForObject("/object?oid=" + body, DigitalObject.class);
         assertThat(body2.getHandle()).isEqualTo("hdl.net");
         assertThat(body2.getTitle()).isEqualTo("Item Title");
     }
 
     @Test
     public void testDelete() {
-        MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
-        map.add("handle", "hdl.net");
-        map.add("title", "Item Title");
-        map.add("metadata_system", "dome");
-        map.add("source_system", "archivesspace");
-        map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
-        String body = this.restTemplate.postForObject("/object",  request,String.class);
+        final MultiValueMap<String, String> map = getRequestParameters();
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
+        String body = this.restTemplate.postForObject("/object", request, String.class);
         assertThat(body).isNotNull();
-        this.restTemplate.delete("/object?oid="+body, DigitalObject.class);
-        DigitalObject body2 = this.restTemplate.getForObject("/object?oid="+body, DigitalObject.class);
+        this.restTemplate.delete("/object?oid=" + body, DigitalObject.class);
+        final DigitalObject body2 = this.restTemplate.getForObject("/object?oid=" + body, DigitalObject.class);
         assertThat(body2.getOid()).isEqualTo(0);
     }
-
 
     @Test
     public void testPatch() {
         // first post the object:
 
-        final MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
-        map.add("handle", "test.post.hdl.net");
-        map.add("title", "Item Title");
-        map.add("metadata_system", "dome");
-        map.add("source_system", "archivesspace");
-        map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
+        final MultiValueMap<String, String> map = getRequestParameters();
         final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
-        final String oid = this.restTemplate.postForObject("/object",  request,String.class);
+        final String oid = this.restTemplate.postForObject("/object", request, String.class);
         assertThat(oid).isNotNull();
-
 
         // now update it:
 
-        final MultiValueMap<String, String> updatedMap= new LinkedMultiValueMap<>();
+        final MultiValueMap<String, String> updatedMap = new LinkedMultiValueMap<>();
         updatedMap.add("oid", oid); // the object id to update
         updatedMap.add("handle", "test.update.hdl.net");
         updatedMap.add("title", "Item Title Updated");
@@ -99,32 +143,31 @@ public class ObjectServiceIT {
         updatedMap.add("source_system", "archivesspace");
         updatedMap.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/21882/112045_sv.jpg?sequence=2");
         final HttpEntity<MultiValueMap<String, String>> updateRequest = new HttpEntity<>(updatedMap, new HttpHeaders());
-        final String body2 = this.restTemplate.patchForObject("/object",  updateRequest,String.class);
+        final String body2 = this.restTemplate.patchForObject("/object", updateRequest, String.class);
         assertThat(body2).isNotNull();
         final DigitalObject body3 = this.restTemplate.getForObject("/object?oid=" + oid, DigitalObject.class);
         assertThat(body3.getHandle()).isEqualTo("test.update.hdl.net");
         assertThat(body3.getTitle()).isEqualTo("Item Title Updated");
     }
 
-
     @Test
     public void testPatchUnsucessful() {
         // first post the object:
 
-        final MultiValueMap<String, String> map= new LinkedMultiValueMap<>();
+        final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
         map.add("handle", "test.post.hdl.net");
         map.add("title", "Item Title");
         map.add("metadata_system", "dome");
         map.add("source_system", "archivesspace");
         map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
         final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, new HttpHeaders());
-        final String oid = this.restTemplate.postForObject("/object",  request,String.class);
+        final String oid = this.restTemplate.postForObject("/object", request, String.class);
         assertThat(oid).isNotNull();
 
 
         // now update it:
 
-        final MultiValueMap<String, String> updatedMap= new LinkedMultiValueMap<>();
+        final MultiValueMap<String, String> updatedMap = new LinkedMultiValueMap<>();
         updatedMap.add("oid", oid); // the object id to update
         updatedMap.add("handle", "test.update.hdl.net");
         updatedMap.add("title", "");
@@ -132,10 +175,21 @@ public class ObjectServiceIT {
         updatedMap.add("source_system", "archivesspace");
         updatedMap.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/21882/112045_sv.jpg?sequence=2");
         final HttpEntity<MultiValueMap<String, String>> updateRequest = new HttpEntity<>(updatedMap, new HttpHeaders());
-        final String body2 = this.restTemplate.patchForObject("/object",  updateRequest,String.class);
+        final String body2 = this.restTemplate.patchForObject("/object", updateRequest, String.class);
         assertThat(body2).isNotNull();
         final DigitalObject body3 = this.restTemplate.getForObject("/object?oid=" + oid, DigitalObject.class);
         assertThat(body3.getTitle()).isEqualTo("Item Title"); // the original title should remain as is since we didn't supply it
+    }
+
+
+    private MultiValueMap<String, String> getRequestParameters() {
+        final MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add("handle", "hdl.net");
+        map.add("title", "Item Title");
+        map.add("metadata_system", "dome");
+        map.add("source_system", "archivesspace");
+        map.add("target_links", "https://dome.mit.edu/bitstream/handle/1721.3/176391/249794_cp.jpg?sequence=1");
+        return map;
     }
 
 

--- a/src/test/java/edu/mit/dos/object/ObjectServiceTest.java
+++ b/src/test/java/edu/mit/dos/object/ObjectServiceTest.java
@@ -16,7 +16,6 @@ import org.springframework.web.servlet.View;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/src/test/java/edu/mit/dos/persistence/DigitalObjectIT.java
+++ b/src/test/java/edu/mit/dos/persistence/DigitalObjectIT.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest
+@ComponentScan("edu.mit.dos.persistence")
 public class DigitalObjectIT {
 
     @Autowired

--- a/src/test/java/edu/mit/dos/persistence/FileIT.java
+++ b/src/test/java/edu/mit/dos/persistence/FileIT.java
@@ -6,13 +6,14 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 @RunWith(SpringRunner.class)
 @DataJpaTest
+@ComponentScan("edu.mit.dos.persistence")
 public class FileIT {
 
     @Autowired

--- a/src/test/java/edu/mit/dos/persistence/ObjectFilePersistenceIT.java
+++ b/src/test/java/edu/mit/dos/persistence/ObjectFilePersistenceIT.java
@@ -4,6 +4,7 @@ import edu.mit.dos.model.DigitalObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
@@ -14,6 +15,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@EnableAutoConfiguration
 @RunWith(SpringRunner.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest

--- a/src/test/java/edu/mit/dos/util/FileConverterTest.java
+++ b/src/test/java/edu/mit/dos/util/FileConverterTest.java
@@ -7,6 +7,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.junit.Assert.*;
 
@@ -23,13 +24,22 @@ public class FileConverterTest {
     // TODO: Remove when file copying capability from Dome is no longer needed.
     @Test
     public void testCreate() throws Exception {
-        final File f = FileConverter.toFile(targetLink);
+        final File f;
+        try {
+            f = FileConverter.toFile(targetLink);
 
-        if (f == null) {
-            fail("File was not copied");
+            if (f == null) {
+                fail("File was not copied");
+            }
+
+
+            assertNotNull(f.getPath());
+            assertTrue(f.length() == Long.valueOf(targetLinkSize));
+
+        } catch (IOException e) {
+
         }
 
-        assertNotNull(f.getPath());
-        assertTrue(f.length() == Long.valueOf(targetLinkSize));
+
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -20,3 +20,12 @@ spring.profiles.active=dev
 # This could also be moved to a Dome specific integration tests properties file
 dome.target.link=https://dome.mit.edu/bitstream/handle/1721.3/56631/147373_cp.jpg?sequence=1
 dome.target.link.size=313762
+
+
+# Note: temporary credentials for testing
+
+security.jwt.token.secret-key=secret-key
+security.jwt.token.expire-length=300000
+
+# Note: temporary testing mode for JWT testing
+serviceConfig.mode=testing


### PR DESCRIPTION
# DOS-162: Add API Auth

Add JWT support for endpoints.

# How to test this?

1. Run the build as usual. This will run the associated tests.
2. To test it live, add env properties to application.properties on the pattern of 
resources/application.properties. This is for testing only. In production mode, the users are read
from the database (and secrets read from a server).
3. POST with username and password. This will return a token. 
4. Pass the token to access the API (e.g., to the GET endpoint below).

`curl -X POST 'http://localhost:8080/users/signin?username=username&password=password'`

`curl -X GET http://localhost:8080/object?oid=1 -H 'Authorization: Bearer TOKEN'`

# Related JIRA tickets

DOS-213

# Includes new or updated dependencies?

No!

