### PR TITLE
Use default credential provider for S3.

### DIFF
--- a/src/main/java/edu/mit/dos/ServiceConfig.java
+++ b/src/main/java/edu/mit/dos/ServiceConfig.java
@@ -15,12 +15,6 @@ import javax.validation.constraints.NotNull;
 public class ServiceConfig {
 
     @NotNull
-    private String accessKey;
-
-    @NotNull
-    private String secretKey;
-
-    @NotNull
     private String bucket;
 
     @NotNull
@@ -34,22 +28,6 @@ public class ServiceConfig {
 
     @NotNull
     private String mode;
-
-    public String getAccessKey() {
-        return accessKey;
-    }
-
-    public void setAccessKey(String accessKey) {
-        this.accessKey = accessKey;
-    }
-
-    public String getSecretKey() {
-        return secretKey;
-    }
-
-    public void setSecretKey(String secretKey) {
-        this.secretKey = secretKey;
-    }
 
     public String getBucket() {
         return bucket;

--- a/src/main/java/edu/mit/dos/storage/S3Impl.java
+++ b/src/main/java/edu/mit/dos/storage/S3Impl.java
@@ -32,18 +32,11 @@ public class S3Impl implements StorageManager {
 
     @PostConstruct
     public void generate() {
-
-        logger.debug("Service username:{}", serviceConfig.getAccessKey());
-        logger.debug("Service password:{}", serviceConfig.getSecretKey());
         logger.debug("Service url:{}", serviceConfig.getBucket());
 
         try {
-            final AWSCredentials credentials =
-                    new BasicAWSCredentials(serviceConfig.getAccessKey(), serviceConfig.getSecretKey());
 
-            s3client = AmazonS3ClientBuilder
-                    .standard()
-                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            s3client = AmazonS3ClientBuilder.standard()
                     .withRegion(Regions.US_EAST_1)
                     .build();
 

--- a/src/test/resources/application-postgres.properties
+++ b/src/test/resources/application-postgres.properties
@@ -5,8 +5,6 @@ security.basic.enable: false
 config.storage=local
 
 # S3 related placeholders - leave as is
-config.accessKey=test
-config.secretKey=test
 config.bucket=test
 config.baseurl=test
 


### PR DESCRIPTION
#### What does this PR do?

Remove the need to read S3 credentials from configuration files.

#### How to test this?

Remove access key and secret key from files that are even in your .gitignore out of safety.

In a Terminal window, export your access key and run the build as usual (set applicaiton.properties to s3 and stage):

export AWS_ACCESS_KEY=test
export AWS_SECRET_ACCESS_KEY=test

mvn clean verify -P failsafe

#### Related JIRA tickets

#### Includes new or updated dependencies?
No
