### PR TITLE
Refactor PATCH endpoint to accept null bitstreams.

### DIFF
--- a/src/main/java/edu/mit/dos/model/DigitalFile.java
+++ b/src/main/java/edu/mit/dos/model/DigitalFile.java
@@ -29,6 +29,8 @@ public class DigitalFile {
     @Column(name = "path")
     private String path;
 
+    @Column(name ="oid")
+    private long oid;
 
     public DigitalFile() {
 
@@ -82,15 +84,24 @@ public class DigitalFile {
         this.path = path;
     }
 
+    public long getOid() {
+        return oid;
+    }
+
+    public void setOid(long oid) {
+        this.oid = oid;
+    }
+
     @Override
     public String toString() {
         return "DigitalFile{" +
                 "fid=" + fid +
-                ", name='" + name +
-                ", type=" + type +
+                ", name='" + name + '\'' +
+                ", type='" + type + '\'' +
                 ", size=" + size +
-                ", checksum='" + checksum +
-                ", path='" + path +
+                ", checksum='" + checksum + '\'' +
+                ", path='" + path + '\'' +
+                ", oid=" + oid +
                 '}';
     }
 }

--- a/src/main/java/edu/mit/dos/model/DigitalObject.java
+++ b/src/main/java/edu/mit/dos/model/DigitalObject.java
@@ -6,7 +6,6 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.StringJoiner;
 
 /**
  * Representation of a digital object
@@ -39,7 +38,7 @@ public class DigitalObject {
     @Column(name = "content_source")
     private String contentSource;
 
-    @OneToMany
+    @OneToMany(cascade = CascadeType.ALL)
     private List<DigitalFile> files =new ArrayList<>();
 
     public DigitalObject() {
@@ -134,10 +133,10 @@ public class DigitalObject {
     }
 
     public String postResponse() {
-        JSONObject response = new JSONObject();
+        final JSONObject response = new JSONObject();
         response.put("oid", oid);
-        List<Long> fids = new ArrayList<>();
-        for (DigitalFile file : files) {
+        final List<Long> fids = new ArrayList<>();
+        for (final DigitalFile file : files) {
             long fid = file.getFid();
             fids.add(fid);
         }

--- a/src/main/java/edu/mit/dos/persistence/FileJpaRepository.java
+++ b/src/main/java/edu/mit/dos/persistence/FileJpaRepository.java
@@ -3,9 +3,6 @@ package edu.mit.dos.persistence;
 import edu.mit.dos.model.DigitalFile;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
-
 public interface FileJpaRepository extends JpaRepository<DigitalFile, Integer> {
 
     DigitalFile findByFid(long fid);

--- a/src/main/java/edu/mit/dos/persistence/ObjectFilePersistenceImpl.java
+++ b/src/main/java/edu/mit/dos/persistence/ObjectFilePersistenceImpl.java
@@ -28,6 +28,7 @@ public class ObjectFilePersistenceImpl implements ObjectFilePersistence {
         for (final String result: storagePaths) {
             final DigitalFile digitalFile = new DigitalFile();
             digitalFile.setPath(result);
+            digitalFile.setOid(object.getOid());
             fileJpaRepository.save(digitalFile);
             object.getFiles().add(digitalFile);
         }

--- a/src/test/java/edu/mit/dos/object/ObjectServiceIT.java
+++ b/src/test/java/edu/mit/dos/object/ObjectServiceIT.java
@@ -183,6 +183,33 @@ public class ObjectServiceIT {
     }
 
     @Test
+    public void testPatchNoFile() {
+        // first post the object:
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        final MultiValueMap<String, Object> map = getRequestParameters2();
+        final HttpEntity    <MultiValueMap<String, Object>> request = new HttpEntity<>(map, headers);
+        final String body = this.restTemplate.postForObject("/object", request, String.class);
+        JSONObject object = (JSONObject) JSONValue.parse(body);
+        String oid = object.getAsString("oid");
+        assertThat(oid).isNotNull();
+
+        // now update it:
+
+        final MultiValueMap<String, Object> updatedMap = new LinkedMultiValueMap<>();
+        updatedMap.add("oid", oid); // the object id to update
+        updatedMap.add("title", "Item Title Updated");
+
+        final HttpEntity<MultiValueMap<String, Object>> updateRequest = new HttpEntity<>(updatedMap, new HttpHeaders());
+        final String body2 = this.restTemplate.patchForObject("/object", updateRequest, String.class);
+        assertThat(body2).isNotNull();
+        final DigitalObject body3 = this.restTemplate.getForObject("/object?oid=" + oid, DigitalObject.class);
+        assertThat(body3.getTitle()).isEqualTo("Item Title Updated");
+    }
+
+    @Test
     public void testPatchUnsucessful() {
         // first post the object:
 


### PR DESCRIPTION
#### What does this PR do?

Allows the PATCH endpoint to not require file as input.

#### How to test this?

1. Start the application with the dev or stage (s3) environment, as usual.
2. Add an object with bitstream via POST.
3. Update the item via PATCH by first not specifying a file and only updating the title.
4. Confirm that the PATCH was successful by doing a GET with the oid.
5. Now update the item again via PATCH, this time specifying a file.
6. Confirm that the PATCH was successful.
7. Confirm that file added is resolvable through the /file endpoint.

It may be useful to return the fields updated as JSON (as we are doing with other end points and as this corresponds to the spec). This could be tackled as a future minor PR, or another commit to this PR.

#### Related JIRA tickets

DOS-287

#### Includes new or updated dependencies?

NO
